### PR TITLE
Fix installing isaac sim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,12 @@ RUN apt-fast install -y \
     yaru-theme-icon \
     lshw \
     lshw-gtk \
-    lsof
+    lsof \
+    gnome-terminal \
+    locales
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
 
 RUN gtk-update-icon-cache /usr/share/icons/Yaru
 RUN mkdir /usr/share/desktop-directories/


### PR DESCRIPTION
I am having trouble installing Isaac-sim, the download process can be completed to the end but the installation process fails.
I fixed docker image which can install isaac-sim for use `gnome-terminal` and `locales` the following errors.

```shell
ubuntu@ubuntu:~$ docker exec -it isaac-sim-enhanced bash
root@rabbit:/isaac-sim# ov-launcher
00:05:55.719 › Omniverse Launcher 1.9.11 (production)
00:05:55.735 › Argv: /tmp/.mount_omniveGfXLYJ/omniverse-launcher --no-sandbox --proxy-server=185.46.212.88:80
00:05:55.735 › Crash dumps directory: /root/.config/omniverse-launcher/Crashpad
00:05:55.739 › Start polling Launcher updates.
[74:0729/000555.883165:ERROR:viz_main_impl.cc(186)] Exiting GPU process due to errors during initialization
00:05:55.883 › Running production web server.
~~~~~~~~~~~~~~~~~~~
00:34:31.250 › [b15f0d24-0292-4d28-b076-d25b0fffacd4] Extracting isaac-sim@2023.1.1 to /root/.local/share/ov/pkg/isaac-sim-2023.1.1...
00:43:56.691 › [b15f0d24-0292-4d28-b076-d25b0fffacd4] Load installation scripts from /root/.local/share/ov/pkg/isaac-sim-2023.1.1
00:43:56.721 › Using proxy server 185.46.212.88:80 for the main process.
00:43:58.272 › [b15f0d24-0292-4d28-b076-d25b0fffacd4] Post-install /root/.local/share/ov/pkg/isaac-sim-2023.1.1/omni.isaac.sim.post.install.sh
00:43:58.274 › Running "/root/.local/share/ov/pkg/isaac-sim-2023.1.1/omni.isaac.sim.post.install.sh"
00:43:58.941 › Dequeue [b15f0d24-0292-4d28-b076-d25b0fffacd4] isaac-sim.
00:43:58.942 › Reset current installer.
00:43:58.953 › [b15f0d24-0292-4d28-b076-d25b0fffacd4] Removing the artifact path /root/.local/share/ov/pkg/isaac-sim-2023.1.1/Isaac Sim.zip due to an error.
00:43:59.122 › [b15f0d24-0292-4d28-b076-d25b0fffacd4] Removing the installation path /root/.local/share/ov/pkg/isaac-sim-2023.1.1 due to an error.
00:44:04.605 › Error: /root/.local/share/ov/pkg/isaac-sim-2023.1.1/omni.isaac.sim.post.install.sh: line 30: gnome-terminal: command not found

    at ChildProcess.<anonymous> (/tmp/.mount_omniveGfXLYJ/resources/app.asar/dist/main.js:410:144608)
    at Object.onceWrapper (node:events:628:26)
    at ChildProcess.emit (node:events:513:28)
    at ChildProcess._handle.onexit (node:internal/child_process:291:12)
00:47:24.703 › Using proxy server 185.46.212.88:80 for the main process.
00:48:19.199 › Using proxy server 185.46.212.88:80 for the main process.
````